### PR TITLE
issue-6: Error compiling clapack on Signaloid

### DIFF
--- a/src/clapack/f2c/err.c
+++ b/src/clapack/f2c/err.c
@@ -25,6 +25,10 @@ extern char* malloc();
 extern "C" {
 #endif
 
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
 /*global definitions*/
 unit        f__units[MXUNIT]; /*unit table*/
 flag        f__init;          /*0 on entry, 1 after initializations*/

--- a/src/clapack/f2c/util.c
+++ b/src/clapack/f2c/util.c
@@ -5,6 +5,10 @@
 extern "C" {
 #endif
 
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
 VOID
 #ifdef KR_headers
 	#define Const /*nothing*/


### PR DESCRIPTION
PR Highlights:

-Added @btsouts fix:
    -Adds some includes into `src/clapack/f2c/err.c` and `src/clapack/f2c/util.c`. 

TODO: Need to understand why this is needed. See 

Closes #6