### PR TITLE
issue-11: Create Make variable for Python executable name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ FRAMEWORK_FLAGS=
 OPTFLAGS=-O3
 DEBUG_FLAGS=
 
+CC=clang
+LD=ld
+PYTHON=python
 
 CONFIGURATION=default
 include $(CONFIGS_DIR)/$(CONFIGURATION).conf
@@ -127,11 +130,11 @@ test: $(TESTS:%=%/test)
 
 .SECONDEXPANSION:
 $(addprefix eg-,$(EXAMPLES)): $(EXAMPLES_DIR)/$$(patsubst eg-%,%,$$@)/Makefile $(LIB)
-	@cd $(EXAMPLES_DIR)/$(patsubst eg-%,%,$@); make run; echo
+	@cd $(EXAMPLES_DIR)/$(patsubst eg-%,%,$@); make run PYTHON=$(PYTHON); echo
 
 .SECONDEXPANSION:
 $(addprefix bm-,$(BENCHMARKS)): $(BENCHMARKS_DIR)/$$(patsubst bm-%,%,$$@)/Makefile $(LIB)
-	cd $(BENCHMARKS_DIR)/$(patsubst bm-%,%,$@); make run
+	cd $(BENCHMARKS_DIR)/$(patsubst bm-%,%,$@); make run PYTHON=$(PYTHON)
 
 
 examples: $(EXAMPLES:%=eg-%)

--- a/benchmarks/tensor-single/Makefile
+++ b/benchmarks/tensor-single/Makefile
@@ -1,4 +1,5 @@
 CC=clang
+PYTHON=python
 
 OPTIMISATION_LEVEL=-O3
 
@@ -55,7 +56,7 @@ $(ENTRYPOINTS_FLAT): $$@.c.o $(LIB)
 .SECONDEXPANSION:
 run: $(ENTRYPOINTS_FLAT)
 	mkdir -p $(RESULTS_DIR)
-	$(foreach ep, $(ENTRYPOINTS), $(BUILD_DIR)/$(ep); python $(PYTHON_SRC)/$(ep).py; echo;)
+	$(foreach ep, $(ENTRYPOINTS), $(BUILD_DIR)/$(ep); $(PYTHON) $(PYTHON_SRC)/$(ep).py; echo;)
 
 clean:
 	rm -fv $(BUILD_DIR)/*

--- a/configs/default.conf
+++ b/configs/default.conf
@@ -1,6 +1,3 @@
-CC=clang
-LD=ld
-
 # macOS default configuration
 ifeq ($(PLATFORM), darwin)
 MAP=-map $(BUILD_DIR)/$(ENTRYPOINT).map

--- a/examples/bnn-inference/Makefile
+++ b/examples/bnn-inference/Makefile
@@ -1,6 +1,8 @@
 N = 2000
 PYTORCH_N_TRAINTING_ITER = 1000
+
 CC=clang
+PYTHON=python
 
 OPTIMISATION_LEVEL=-O3
 
@@ -49,9 +51,9 @@ build: $(ENTRYPOINTS_FLAT)
 run: $(ENTRYPOINTS_FLAT)
 	@echo ...............................................................................
 	@echo Running bnn-inference
-	python src/pytorch.py $(N) $(PYTORCH_N_TRAINTING_ITER)
+	$(PYTHON) src/pytorch.py $(N) $(PYTORCH_N_TRAINTING_ITER)
 	./$(BUILD_DIR)/bnn-inference $(N)
-	python src/analyse.py
+	$(PYTHON) src/analyse.py
 	@echo ...............................................................................
 
 clean:

--- a/examples/bnn-simple/Makefile
+++ b/examples/bnn-simple/Makefile
@@ -8,6 +8,7 @@ N_LAYERS = 2
 PRINT_FREQUENCY = 200
 
 CC=clang
+PYTHON=python
 
 OPTIMISATION_LEVEL=-O3
 
@@ -58,14 +59,14 @@ run: $(ENTRYPOINTS_FLAT) $(SRC_DIR)/generate_data.py
 	mkdir -p $(DATA_DIR)
 	mkdir -p $(PLOTS_DIR)
 	rm $(DATA_DIR)/*
-	python $(SRC_DIR)/generate_data.py $(N_DATA_PONTS) $(N_TEST_DATA_POINTS)
-	python $(SRC_DIR)/generate_random_values.py $(LEARNING_RATE) $(N) $(N_TEST_DATA_POINTS) $(N_REPETITIONS) $(N_DATA_PONTS) $(N_NODES) $(N_LAYERS)
+	$(PYTHON) $(SRC_DIR)/generate_data.py $(N_DATA_PONTS) $(N_TEST_DATA_POINTS)
+	$(PYTHON) $(SRC_DIR)/generate_random_values.py $(LEARNING_RATE) $(N) $(N_TEST_DATA_POINTS) $(N_REPETITIONS) $(N_DATA_PONTS) $(N_NODES) $(N_LAYERS)
 	@echo Pascal
 	./$(BUILD_DIR)/bnn-simple $(LEARNING_RATE) $(N) $(N_TEST_DATA_POINTS) $(N_REPETITIONS) $(N_DATA_PONTS) $(N_NODES) $(N_LAYERS) $(PRINT_FREQUENCY)
 	@echo
 	@echo PyTorch
-	python $(SRC_DIR)/experiment.py $(LEARNING_RATE) $(N) $(N_TEST_DATA_POINTS) $(N_REPETITIONS) $(N_DATA_PONTS) $(N_NODES) $(N_LAYERS) $(PRINT_FREQUENCY)
-	python $(SRC_DIR)/plot.py $(N_TEST_DATA_POINTS) $(N_REPETITIONS) $(N_DATA_PONTS)
+	$(PYTHON) $(SRC_DIR)/experiment.py $(LEARNING_RATE) $(N) $(N_TEST_DATA_POINTS) $(N_REPETITIONS) $(N_DATA_PONTS) $(N_NODES) $(N_LAYERS) $(PRINT_FREQUENCY)
+	$(PYTHON) $(SRC_DIR)/plot.py $(N_TEST_DATA_POINTS) $(N_REPETITIONS) $(N_DATA_PONTS)
 	@echo ...............................................................................
 
 clean:

--- a/examples/gp-simple/Makefile
+++ b/examples/gp-simple/Makefile
@@ -1,4 +1,5 @@
 CC=clang
+PYTHON=python
 
 OPTIMISATION_LEVEL=-O0
 
@@ -30,7 +31,7 @@ run: $(BUILD_DIR)/$(ENTRYPOINT) $(ENTRYPOINT).c plot.py
 	@echo Running gp-simple
 	mkdir -p $(RESULTS_DIR)
 	mkdir -p $(PLOTS_DIR)
-	./$(BUILD_DIR)/$(ENTRYPOINT); python plot.py
+	./$(BUILD_DIR)/$(ENTRYPOINT); $(PYTHON) plot.py
 	@echo ...............................................................................
 
 clean:

--- a/examples/nn-simple/Makefile
+++ b/examples/nn-simple/Makefile
@@ -1,4 +1,5 @@
 CC=clang
+PYTHON=python
 
 OPTIMISATION_LEVEL=-O3
 
@@ -48,7 +49,7 @@ run: $(ENTRYPOINTS_FLAT)  $(SRC_DIR)/generate_data.py
 	mkdir -p $(RESULTS_DIR)
 	mkdir -p $(DATA_DIR)
 	mkdir -p $(PLOTS_DIR)
-	python $(SRC_DIR)/generate_data.py
+	$(PYTHON) $(SRC_DIR)/generate_data.py
 	$(foreach executable,$(ENTRYPOINTS_FLAT),$(executable);)
 	@echo ...............................................................................
 


### PR DESCRIPTION
PR Highlights:
- [Moved default CC and LD to Makefile](https://github.com/physical-computation/pascal/commit/b7df60449f6d1e833bc47a8a3a1a0bba7814a39a)
- [Added PYTHON=python make variable that propagates to examples and benchmarks](https://github.com/physical-computation/pascal/commit/bb857880701f02050ff3ca62fedc681e48da6ec1)